### PR TITLE
deduplicate identical tags (same tag type and value)

### DIFF
--- a/src/tag/TagBuilder.cxx
+++ b/src/tag/TagBuilder.cxx
@@ -199,12 +199,15 @@ TagBuilder::AddItemInternal(TagType type, StringView value)
 		value = { f.data, f.size };
 
 	tag_pool_lock.lock();
-	auto i = tag_pool_get_item(type, value);
+	auto item = tag_pool_get_item(type, value);
 	tag_pool_lock.unlock();
 
 	free(f.data);
 
-	items.push_back(i);
+	if (std::find(items.begin(), items.end(), item) == items.end()) {
+		/* the tag isn't a duplicate */
+		items.push_back(item);
+	}
 }
 
 void

--- a/src/tag/TagItem.hxx
+++ b/src/tag/TagItem.hxx
@@ -22,6 +22,7 @@
 
 #include "TagType.h"
 #include "Compiler.h"
+#include <string.h>
 
 /**
  * One tag value.  It is a mapping of #TagType to am arbitrary string
@@ -40,6 +41,10 @@ struct TagItem {
 	TagItem() = default;
 	TagItem(const TagItem &other) = delete;
 	TagItem &operator=(const TagItem &other) = delete;
+	bool operator==(const TagItem &other) const {
+		return this->type == other.type &&
+			strcmp(this->value, other.value) == 0;
+	}
 } gcc_packed;
 
 #endif


### PR DESCRIPTION
this fixes problems with duplicate values for track/tracknumber, disc/discnumber etc. without side effects.