### PR TITLE
Provide audio format to pipe output command

### DIFF
--- a/doc/user.xml
+++ b/doc/user.xml
@@ -3076,7 +3076,7 @@ buffer_size: 16384</programlisting>
                   <parameter>CMD</parameter>
                 </entry>
                 <entry>
-                  This command is invoked with the shell.
+                  This command is invoked with the shell. The command may contain one or more of the strings $MPDPIPE_BITS, $MPDPIPE_CHANNELS, $MPDPIPE_RATE, $MPDPIPE_FORMAT. Before the command is invoked MPD will substitute these strings by the number of bits per sample, the number of channels, the sample rate, and the sample format (one of "S8", "S16", "S24_P32", "S32", "FLOAT" or "DSD"), respectively. 
                 </entry>
               </row>
             </tbody>


### PR DESCRIPTION
So far, the pipe output of MPD had the problem that the commands
in the pipe had no information about the format of the raw audio data
sent into the pipe.

With this patch mpd substitutes the strings "$MPDPIPE_BITS",
"$MPDPIPE_CHANNELS", "$MPDPIPE_RATE", "$MPDPIPE_FORMAT"
within the command started for the pipe by the number of bits per sample,
the number of channels, the sample rate, and the sample format (one of
"S8", "S16", "S24_P32" or "S32"), respectively.

Example: if in mpd.conf an audio_output of type pipe contains the line

        command         "/usr/local/bin/mympdpipe $MPDPIPE_BITS $MPDPIPE_CHANNELS $MPDPIPE_RATE $MPDPIPE_FORMAT"

then mpd starts a command like
        /usr/local/bin/mympdpipe 16 2 44100 S16
for this pipe.