### PR TITLE
Provide audio format to pipe output command

### DIFF
--- a/doc/user.xml
+++ b/doc/user.xml
@@ -3059,6 +3059,10 @@ buffer_size: 16384</programlisting>
         <para>
           The <varname>pipe</varname> plugin starts a program and
           writes raw PCM data into its standard input.
+          The environment variables MPDPIPE_BITS, MPDPIPE_CHANNELS and
+          MPDPIPE_RATE are set to the number of bits per sample,
+          the number of channels and the sample rate of the raw data,
+          respectively.
         </para>
 
         <informaltable>

--- a/src/output/plugins/PipeOutputPlugin.cxx
+++ b/src/output/plugins/PipeOutputPlugin.cxx
@@ -28,7 +28,11 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#ifndef WIN32
 #include <unistd.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#endif
 
 class PipeOutput {
 	friend struct AudioOutputWrapper<PipeOutput>;
@@ -37,6 +41,9 @@ class PipeOutput {
 
 	std::string cmd;
 	FILE *fh;
+#ifndef WIN32
+	pid_t childpid;
+#endif
 
 	PipeOutput()
 		:base(pipe_output_plugin) {}
@@ -49,7 +56,13 @@ public:
 	bool Open(AudioFormat &audio_format, Error &error);
 
 	void Close() {
+#ifdef WIN32
 		pclose(fh);
+#else
+		int status;
+		fclose(fh);
+		waitpid(childpid, &status, 0);
+#endif
 	}
 
 	size_t Play(const void *chunk, size_t size, Error &error);
@@ -84,12 +97,30 @@ PipeOutput::Create(const ConfigBlock &block, Error &error)
 	return po;
 }
 
+#define set_MPDPIPE_vars(audio_format) {\
+	char strbuf[8];\
+	setenv("MPDPIPE_BITS", sample_format_to_string(audio_format.format), 1);\
+	snprintf(strbuf, sizeof(strbuf), "%u", audio_format.sample_rate);\
+	setenv("MPDPIPE_RATE", strbuf, 1);\
+	snprintf(strbuf, sizeof(strbuf), "%u", audio_format.channels);\
+	setenv("MPDPIPE_CHANNELS", strbuf, 1);\
+}
+
 inline bool
 PipeOutput::Open(AudioFormat &audio_format, Error &error)
 {
+#ifdef WIN32
+	set_MPDPIPE_vars(audio_format);
+	fh = popen(cmd.c_str(), "w");
+	if (fh == nullptr) {
+		error.FormatErrno("Error opening pipe \"%s\"",
+				  cmd.c_str());
+		return false;
+	}
+
+	return true;
+#else
 	int pfdes[2];
-	pid_t childpid;
-	char strbuf[8];
 
 	if (pipe(pfdes) == -1) {
 		error.FormatErrno("Error opening pipe for output.");
@@ -112,15 +143,12 @@ PipeOutput::Open(AudioFormat &audio_format, Error &error)
 		close(pfdes[1]);
 		dup2(pfdes[0], 0);
 		close(pfdes[0]);
-		setenv("MPDPIPE_BITS", sample_format_to_string(audio_format.format), 1);
-		snprintf(strbuf, sizeof(strbuf), "%u", audio_format.sample_rate);
-		setenv("MPDPIPE_RATE", strbuf, 1);
-		snprintf(strbuf, sizeof(strbuf), "%u", audio_format.channels);
-		setenv("MPDPIPE_CHANNELS", strbuf, 1);
+		set_MPDPIPE_vars(audio_format);
 		execlp("sh", "/bin/sh", "-c", cmd.c_str(), (char*)NULL);
 		error.FormatErrno("Cannot execute pipe program \"%s\"", cmd.c_str());
 		abort();
 	}
+#endif
 }
 
 inline size_t

--- a/src/output/plugins/PipeOutputPlugin.cxx
+++ b/src/output/plugins/PipeOutputPlugin.cxx
@@ -27,6 +27,7 @@
 #include <string>
 
 #include <stdio.h>
+#include <stdlib.h>
 
 class PipeOutput {
 	friend struct AudioOutputWrapper<PipeOutput>;
@@ -83,8 +84,15 @@ PipeOutput::Create(const ConfigBlock &block, Error &error)
 }
 
 inline bool
-PipeOutput::Open(gcc_unused AudioFormat &audio_format, Error &error)
+PipeOutput::Open(AudioFormat &audio_format, Error &error)
 {
+	char strbuf[8];
+	setenv("MPDPIPE_BITS", sample_format_to_string(audio_format.format), 1);
+	snprintf(strbuf, sizeof(strbuf), "%u", audio_format.sample_rate);
+	setenv("MPDPIPE_RATE", strbuf, 1);
+	snprintf(strbuf, sizeof(strbuf), "%u", audio_format.channels);
+	setenv("MPDPIPE_CHANNELS", strbuf, 1);
+
 	fh = popen(cmd.c_str(), "w");
 	if (fh == nullptr) {
 		error.FormatErrno("Error opening pipe \"%s\"",


### PR DESCRIPTION
So far, the pipe output of MPD had the problem that the commands
in the pipe had no information about the format of the raw audio data
sent into the pipe.

With this patch mpd sets the environment variables
    MPDPIPE_BITS,
    MPDPIPE_CHANNELS,
    MPDPIPE_RATE
to the number of bits per sample,
the number of channels, and the sample rate of the raw PCM sent to the
pipe, respectively. These variables can then be used in the command or
within a script which is started for the pipe.