### PR TITLE
Player DSF, DFF file incorrect speed  . Background white noise

### DIFF
--- a/src/decoder/plugins/DsdiffDecoderPlugin.cxx
+++ b/src/decoder/plugins/DsdiffDecoderPlugin.cxx
@@ -428,7 +428,7 @@ dsdiff_stream_decode(Decoder &decoder, InputStream &is)
 
 	Error error;
 	AudioFormat audio_format;
-	if (!audio_format_init_checked(audio_format, metadata.sample_rate / 8,
+	if (!audio_format_init_checked(audio_format, metadata.sample_rate / 8 / 4,
 				       SampleFormat::DSD,
 				       metadata.channels, error)) {
 		LogError(error);
@@ -467,7 +467,7 @@ dsdiff_scan_stream(InputStream &is,
 		return false;
 
 	AudioFormat audio_format;
-	if (!audio_format_init_checked(audio_format, metadata.sample_rate / 8,
+	if (!audio_format_init_checked(audio_format, metadata.sample_rate / 8 / 4,
 				       SampleFormat::DSD,
 				       metadata.channels, IgnoreError()))
 		/* refuse to parse files which we cannot play anyway */

--- a/src/decoder/plugins/DsfDecoderPlugin.cxx
+++ b/src/decoder/plugins/DsfDecoderPlugin.cxx
@@ -309,7 +309,7 @@ dsf_stream_decode(Decoder &decoder, InputStream &is)
 
 	Error error;
 	AudioFormat audio_format;
-	if (!audio_format_init_checked(audio_format, metadata.sample_rate / 8,
+	if (!audio_format_init_checked(audio_format, metadata.sample_rate / 8 / 4,
 				       SampleFormat::DSD,
 				       metadata.channels, error)) {
 		LogError(error);
@@ -340,7 +340,7 @@ dsf_scan_stream(InputStream &is,
 		return false;
 
 	AudioFormat audio_format;
-	if (!audio_format_init_checked(audio_format, metadata.sample_rate / 8,
+	if (!audio_format_init_checked(audio_format, metadata.sample_rate / 8 / 4,
 				       SampleFormat::DSD,
 				       metadata.channels, IgnoreError()))
 		/* refuse to parse files which we cannot play anyway */

--- a/src/output/plugins/AlsaOutputPlugin.cxx
+++ b/src/output/plugins/AlsaOutputPlugin.cxx
@@ -695,7 +695,7 @@ AlsaOutput::SetupDop(const AudioFormat audio_format,
 
 	AudioFormat dop_format = audio_format;
 	dop_format.format = SampleFormat::S24_P32;
-	dop_format.sample_rate /= 2;
+	dop_format.sample_rate *= 2;
 
 	const AudioFormat check = dop_format;
 

--- a/src/pcm/PcmDsd.cxx
+++ b/src/pcm/PcmDsd.cxx
@@ -78,8 +78,8 @@ PcmDsd::ToFloat(unsigned channels, ConstBuffer<uint8_t> src)
 static constexpr inline uint32_t
 Construct32(uint8_t a, uint8_t b, uint8_t c, uint8_t d)
 {
-	return uint32_t(a) | (uint32_t(b) << 8) |
-		(uint32_t(c) << 16) | (uint32_t(d) << 24);
+	return uint32_t(a) << 24 | (uint32_t(b) << 16) |
+		(uint32_t(c) << 8) | uint32_t(d) ;
 }
 
 static constexpr inline uint32_t


### PR DESCRIPTION

ALSA DSD_U32_BE correction mode , the player DSF, DFF file incorrect speed : 4x speed playback . Background white noise