### PR TITLE
return id for "addid" with position

### DIFF
--- a/src/command/QueueCommands.cxx
+++ b/src/command/QueueCommands.cxx
@@ -122,6 +122,7 @@ handle_addid(Client &client, Request args, Response &r)
 
 		try {
 			client.partition.MoveId(added_id, to);
+			r.Format("Id: %u\n", added_id);
 			return CommandResult::OK;
 		} catch (...) {
 			/* rollback */


### PR DESCRIPTION
Previously the id was being returned only when a position wasn't
specified.