### PR TITLE
output/osx: wait-free render callback

### DIFF
--- a/src/output/plugins/OSXOutputPlugin.cxx
+++ b/src/output/plugins/OSXOutputPlugin.cxx
@@ -614,6 +614,7 @@ osx_output_play(AudioOutput *ao, const void *chunk, size_t size,
 {
 	OSXOutput *od = (OSXOutput *)ao;
 
+	od->mutex.lock();
 	while (true) {
 		if (od->ring_buffer->write_available() > 0)
 			break;
@@ -621,6 +622,7 @@ osx_output_play(AudioOutput *ao, const void *chunk, size_t size,
 		/* wait for some free space in the buffer */
 		od->condition.wait(od->mutex);
 	}
+	od->mutex.unlock();
 
 	return od->ring_buffer->push((uint8_t *) chunk, size);
 }

--- a/src/output/plugins/OSXOutputPlugin.cxx
+++ b/src/output/plugins/OSXOutputPlugin.cxx
@@ -417,12 +417,16 @@ osx_render(void *vdata,
 		of an incomplete last frame, keep popping until the
 		last frame is complete.
 	*/
-	size_t remainder;
-	while ((remainder = available_bytes % input_buffer_frame_size) > 0)
+	while (true) {
+		size_t incomplete_frame_bytes = available_bytes % input_buffer_frame_size;
+		if (incomplete_frame_bytes == 0)
+			break;
+
 		available_bytes += od->ring_buffer->pop(
 			od->render_buffer + available_bytes,
-			input_buffer_frame_size - remainder
+			input_buffer_frame_size - incomplete_frame_bytes
 		);
+	}
 
 	od->condition.signal(); // We are done consuming from ring_buffer
 

--- a/src/output/plugins/OSXOutputPlugin.cxx
+++ b/src/output/plugins/OSXOutputPlugin.cxx
@@ -410,18 +410,18 @@ osx_render(void *vdata,
 		requested_bytes = od->render_buffer_size;
 
 	size_t available_bytes = od->ring_buffer->pop(od->render_buffer, requested_bytes);
-	size_t wraparound_remainder = available_bytes % input_buffer_frame_size;
 
 	/*
 		Maybe this is paranoid but we have no way of knowing
 		if the 'pop' above ended at a frame boundary. In case
-		of an incomplete last frame, do a second pop to get
-		enough bytes to complete the last frame.
+		of an incomplete last frame, keep popping until the
+		last frame is complete.
 	*/
-	if (wraparound_remainder > 0)
+	size_t remainder;
+	while ((remainder = available_bytes % input_buffer_frame_size) > 0)
 		available_bytes += od->ring_buffer->pop(
 			od->render_buffer + available_bytes,
-			input_buffer_frame_size - wraparound_remainder
+			input_buffer_frame_size - remainder
 		);
 
 	od->condition.signal(); // We are done consuming from ring_buffer


### PR DESCRIPTION
Closes https://bugs.musicpd.org/view.php?id=4537 .

Removed the 'cancel' function because it violates 'single producer,
single consumer'.