### PR TITLE
A lot of improvements to OS X output plugin

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -29,3 +29,4 @@ The following people have contributed code to MPD:
  Denis Krjuchkov <denis@crazydev.net>
  Jurgen Kramer <gtmkramer@xs4all.nl>
  Jean-Francois Dockes <jf@dockes.org>
+ Yue Wang <yuleopen@gmail.com>

--- a/doc/user.xml
+++ b/doc/user.xml
@@ -3169,6 +3169,28 @@ buffer_size: 16384</programlisting>
               </row>
               <row>
                 <entry>
+                  <varname>hog_device</varname>
+                  <parameter>yes|no</parameter>
+                </entry>
+                <entry>
+                  Hog the device. This means that it takes exclusive control of the audio
+                  output device it is playing through, and no other program can access it.
+                </entry>
+              </row>
+              <row>
+                <entry>
+                  <varname>sync_sample_rate</varname>
+                  <parameter>yes|no</parameter>
+                </entry>
+                <entry>
+                  Synchronize the sample rate. It will try to set the output device sample
+                  rate to the corresponding sample rate of the file playing. If the output
+                  device does not support the sample rate the track has, it will try to 
+                  select the best possible for each file.
+                </entry>
+              </row>
+              <row>
+                <entry>
                   <varname>channel_map</varname>
                   <parameter>SOURCE,SOURCE,...</parameter>
                 </entry>

--- a/src/output/plugins/OSXOutputPlugin.cxx
+++ b/src/output/plugins/OSXOutputPlugin.cxx
@@ -30,8 +30,7 @@
 #include <CoreAudio/CoreAudio.h>
 #include <AudioUnit/AudioUnit.h>
 #include <CoreServices/CoreServices.h>
-#include <libkern/OSAtomic.h>
-#include<boost/lockfree/spsc_queue.hpp>
+#include <boost/lockfree/spsc_queue.hpp>
 
 struct OSXOutput {
 	AudioOutput base;

--- a/src/output/plugins/OSXOutputPlugin.cxx
+++ b/src/output/plugins/OSXOutputPlugin.cxx
@@ -710,7 +710,7 @@ osx_output_open(AudioOutput *ao, AudioFormat &audio_format,
 		return false;
 	}
 
-	UInt32 buffer_frame_size;
+	UInt32 buffer_frame_size = 1;
 	status = osx_output_set_buffer_size(od->au, od->asbd, &buffer_frame_size);
 	if (status != noErr) {
 		osx_os_status_to_cstring(status, errormsg, sizeof(errormsg));

--- a/src/output/plugins/OSXOutputPlugin.cxx
+++ b/src/output/plugins/OSXOutputPlugin.cxx
@@ -631,7 +631,9 @@ osx_output_enable(AudioOutput *ao, Error &error)
 		return false;
 	}
 
-	osx_output_hog_device(oo->dev_id, true);
+        if (oo->component_subtype == kAudioUnitSubType_HALOutput) {
+		osx_output_hog_device(oo->dev_id, true);
+        }
 
 	AURenderCallbackStruct callback;
 	callback.inputProc = osx_render;
@@ -659,7 +661,9 @@ osx_output_disable(AudioOutput *ao)
 
 	AudioComponentInstanceDispose(oo->au);
 
-	osx_output_hog_device(oo->dev_id, false);
+        if (oo->component_subtype == kAudioUnitSubType_HALOutput) {
+		osx_output_hog_device(oo->dev_id, false);
+        }
 }
 
 static void


### PR DESCRIPTION
Add sample rate synchronization, which ensures mpd play bit perfectly on OS X. User can enable this by setting sync_sample_rate to "true".

Add device hogging capability. This forbids other process interfere with selected user devices. User may enable this by setting "hog_device" to "true".

Kill the mutex, locks, extra buffer in original code. Now you'll see greater than 3X performance improvement.

Set the right buffer length for the device.

Fix an audio unit initialization problem. 

Code borrowed from the CMUS project. I am the author of cmus coreaudio output plugin. So I have full rights to redistribute the code. The coding style may be slightly different, but we can always polish/refactor it in another PR. 

@jacobvosmaer Please take a look.

@MaxKellermann please merge.