### PR TITLE
use osx_output_delay to wait until ring buffer is able to write

### DIFF
--- a/src/output/OutputPlugin.hxx
+++ b/src/output/OutputPlugin.hxx
@@ -93,10 +93,11 @@ struct AudioOutputPlugin {
 	void (*close)(AudioOutput *data);
 
 	/**
-	 * Returns a positive number if the output thread shall delay
-	 * the next call to play() or pause().  This should be
-	 * implemented instead of doing a sleep inside the plugin,
-	 * because this allows MPD to listen to commands meanwhile.
+	 * Returns a positive number if the output thread shall further
+	 * delay the next call to play() or pause(), which will happen
+	 * until this function returns 0.  This should be implemented
+	 * instead of doing a sleep inside the plugin, because this 
+	 * allows MPD to listen to commands meanwhile.
 	 *
 	 * @return the number of milliseconds to wait
 	 */

--- a/src/output/plugins/OSXOutputPlugin.cxx
+++ b/src/output/plugins/OSXOutputPlugin.cxx
@@ -740,13 +740,14 @@ osx_output_play(AudioOutput *ao, const void *chunk, size_t size,
 		gcc_unused Error &error)
 {
 	OSXOutput *od = (OSXOutput *)ao;
-	while (!od->ring_buffer->write_available()) {
-		struct timespec req;
-		req.tv_sec = 0;
-		req.tv_nsec = 25 * 1e6;
-		nanosleep(&req, NULL);
-	}
 	return od->ring_buffer->push((uint8_t *)chunk, size);
+}
+
+static unsigned
+osx_output_delay(AudioOutput *ao)
+{
+	OSXOutput *od = (OSXOutput *)ao;
+	return od->ring_buffer->write_available() ? 0 : 25;
 }
 
 const struct AudioOutputPlugin osx_output_plugin = {
@@ -758,7 +759,7 @@ const struct AudioOutputPlugin osx_output_plugin = {
 	osx_output_disable,
 	osx_output_open,
 	osx_output_close,
-	nullptr,
+	osx_output_delay,
 	nullptr,
 	osx_output_play,
 	nullptr,


### PR DESCRIPTION
This further optimize the performance. 

This is now working properly with a conditional variable bug being fixed (8bbfb5cda12e105460c1e2bf22066873ecc29b0f).