### PR TITLE
Fix comment in mpdconf.example ("can setting can" -> "setting can")

### DIFF
--- a/doc/mpdconf.example
+++ b/doc/mpdconf.example
@@ -165,7 +165,7 @@
 # Permissions #################################################################
 #
 # If this setting is set, MPD will require password authorization. The password
-# can setting can be specified multiple times for different password profiles.
+# setting can be specified multiple times for different password profiles.
 #
 #password                        "password@read,add,control,admin"
 #


### PR DESCRIPTION
There is a small error in the sample configuration file. This commits fixes it.