### PR TITLE
add playnext and playnextid - jump in playlist after current track finishes

### DIFF
--- a/doc/protocol.xml
+++ b/doc/protocol.xml
@@ -892,6 +892,36 @@
             </para>
           </listitem>
         </varlistentry>
+        <varlistentry id="command_playnext">
+          <term>
+            <cmdsynopsis>
+              <command>playnext</command>
+              <arg choice="req"><replaceable>SONGPOS</replaceable></arg>
+            </cmdsynopsis>
+          </term>
+          <listitem>
+            <para>
+              Goes to the song number
+              <varname>SONGPOS</varname>
+              in the playlist after the current song.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry id="command_playnextid">
+          <term>
+            <cmdsynopsis>
+              <command>playnextid</command>
+              <arg choice="req"><replaceable>SONGID</replaceable></arg>
+            </cmdsynopsis>
+          </term>
+          <listitem>
+            <para>
+              Goes to the song
+              <varname>SONGID</varname>
+              in the playlist after the current song.
+            </para>
+          </listitem>
+        </varlistentry>
         <varlistentry id="command_previous">
           <term>
             <cmdsynopsis>

--- a/src/Partition.hxx
+++ b/src/Partition.hxx
@@ -137,6 +137,14 @@ struct Partition final : QueueListener, PlayerListener, MixerListener {
 		return playlist.PlayId(pc, id);
 	}
 
+	void PlayNextPosition(int position) {
+		return playlist.PlayNextPosition(pc, position);
+	}
+
+	void PlayNextId(int id) {
+		return playlist.PlayNextId(pc, id);
+	}
+
 	void PlayNext() {
 		return playlist.PlayNext(pc);
 	}

--- a/src/command/AllCommands.cxx
+++ b/src/command/AllCommands.cxx
@@ -148,6 +148,8 @@ static constexpr struct command commands[] = {
 	{ "playlistinfo", PERMISSION_READ, 0, 1, handle_playlistinfo },
 	{ "playlistmove", PERMISSION_CONTROL, 3, 3, handle_playlistmove },
 	{ "playlistsearch", PERMISSION_READ, 2, -1, handle_playlistsearch },
+	{ "playnext", PERMISSION_CONTROL, 1, 1, handle_playnext },
+	{ "playnextid", PERMISSION_CONTROL, 1, 1, handle_playnextid },
 	{ "plchanges", PERMISSION_READ, 1, 2, handle_plchanges },
 	{ "plchangesposid", PERMISSION_READ, 1, 2, handle_plchangesposid },
 	{ "previous", PERMISSION_CONTROL, 0, 0, handle_previous },

--- a/src/command/PlayerCommands.cxx
+++ b/src/command/PlayerCommands.cxx
@@ -77,6 +77,24 @@ handle_playid(Client &client, Request args, gcc_unused Response &r)
 }
 
 CommandResult
+handle_playnext(Client &client, Request args, gcc_unused Response &r)
+{
+	int song = args.ParseInt(0);
+
+	client.partition.PlayNextPosition(song);
+	return CommandResult::OK;
+}
+
+CommandResult
+handle_playnextid(Client &client, Request args, gcc_unused Response &r)
+{
+	int id = args.ParseInt(0);
+
+	client.partition.PlayNextId(id);
+	return CommandResult::OK;
+}
+
+CommandResult
 handle_stop(Client &client, gcc_unused Request args, gcc_unused Response &r)
 {
 	client.partition.Stop();

--- a/src/command/PlayerCommands.hxx
+++ b/src/command/PlayerCommands.hxx
@@ -33,6 +33,12 @@ CommandResult
 handle_playid(Client &client, Request request, Response &response);
 
 CommandResult
+handle_playnext(Client &client, Request request, Response &response);
+
+CommandResult
+handle_playnextid(Client &client, Request request, Response &response);
+
+CommandResult
 handle_stop(Client &client, Request request, Response &response);
 
 CommandResult

--- a/src/queue/Playlist.hxx
+++ b/src/queue/Playlist.hxx
@@ -283,12 +283,22 @@ public:
 	/**
 	 * Throws std::runtime_error or #Error on error.
 	 */
+	void PlayNextPosition(PlayerControl &pc, int position);
+
+	/**
+	 * Throws std::runtime_error or #Error on error.
+	 */
 	void PlayOrder(PlayerControl &pc, unsigned order);
 
 	/**
 	 * Throws std::runtime_error or #Error on error.
 	 */
 	void PlayId(PlayerControl &pc, int id);
+
+	/**
+	 * Throws std::runtime_error or #Error on error.
+	 */
+	void PlayNextId(PlayerControl &pc, int id);
 
 	/**
 	 * Throws std::runtime_error or #Error on error.

--- a/src/queue/PlaylistControl.cxx
+++ b/src/queue/PlaylistControl.cxx
@@ -113,7 +113,7 @@ playlist::PlayNextPosition(PlayerControl &pc, int song)
 	if (!queue.IsValidPosition(song))
 		throw PlaylistError::BadRange();
 
-	queue.SetNextOrder(song);
+	queue.SetNextPosition(song);
 }
 
 void

--- a/src/queue/PlaylistControl.cxx
+++ b/src/queue/PlaylistControl.cxx
@@ -106,6 +106,17 @@ playlist::PlayPosition(PlayerControl &pc, int song)
 }
 
 void
+playlist::PlayNextPosition(PlayerControl &pc, int song)
+{
+	pc.LockClearError();
+
+	if (!queue.IsValidPosition(song))
+		throw PlaylistError::BadRange();
+
+	queue.SetNextOrder(song);
+}
+
+void
 playlist::PlayId(PlayerControl &pc, int id)
 {
 	if (id == -1) {
@@ -118,6 +129,16 @@ playlist::PlayId(PlayerControl &pc, int id)
 		throw PlaylistError::NoSuchSong();
 
 	PlayPosition(pc, song);
+}
+
+void
+playlist::PlayNextId(PlayerControl &pc, int id)
+{
+	int song = queue.IdToPosition(id);
+	if (song < 0)
+		throw PlaylistError::NoSuchSong();
+
+	PlayNextPosition(pc, song);
 }
 
 void

--- a/src/queue/Queue.hxx
+++ b/src/queue/Queue.hxx
@@ -87,6 +87,10 @@ struct Queue {
 	/** map song ids to positions */
 	IdTable id_table;
 
+	/** play this song after the current song finishes?
+	    set to -1 when inactive. */
+	int next;
+
 	/** repeat playback when the end of the queue has been
 	    reached? */
 	bool repeat;
@@ -227,12 +231,26 @@ struct Queue {
 
 	/**
 	 * Returns the order number following the specified one.  This takes
-	 * end of queue and "repeat" mode into account.
+	 * end of queue, "repeat" mode and playnext into account.
 	 *
 	 * @return the next order number, or -1 to stop playback
 	 */
 	gcc_pure
-	int GetNextOrder(unsigned order) const;
+	int GetNextOrder(unsigned order);
+
+	/**
+	 * Sets the next song to be played after the current song finishes.
+	 * used by playnext and playnextid
+	 */
+	void SetNextOrder(unsigned order);
+
+	/**
+	 * Sets the next song to be played after the current song finishes.
+	 * used by playnext and playnextid
+	 */
+	void SetNextPosition(unsigned position) {
+		SetNextOrder(PositionToOrder(position));
+	}
 
 	/**
 	 * Increments the queue's version number.  This handles integer
@@ -279,6 +297,7 @@ struct Queue {
 	 * Swaps two songs, addressed by their order number.
 	 */
 	void SwapOrders(unsigned order1, unsigned order2) {
+		next = -1;
 		std::swap(order[order1], order[order2]);
 	}
 
@@ -306,6 +325,7 @@ struct Queue {
 	 * Initializes the "order" array, and restores "normal" order.
 	 */
 	void RestoreOrder() {
+		next = -1;
 		for (unsigned i = 0; i < length; ++i)
 			order[i] = i;
 	}
@@ -357,6 +377,7 @@ private:
 
 	void MoveItemTo(unsigned from, unsigned to) {
 		unsigned from_id = items[from].id;
+		next = -1;
 
 		items[to] = items[from];
 		items[to].version = version;


### PR DESCRIPTION
I was trying to convert my friend from foobar2000 when he noticed that MPD doesn't allow you to automatically jump in the playlist after the current track finishes playing.
The important changes here are in Queue.cxx and Queue.hxx, both of which may seem like an ugly hack if you know better ways to do this. Improvements could be to try to keep track of where the next track is going to be after either positions or the order changes.
Another way to do this could be to rewrite the order map.