### PR TITLE
doc/protocol: Turn the link to the UTF-8 FAQ into a ulink element

### DIFF
--- a/doc/protocol.xml
+++ b/doc/protocol.xml
@@ -67,7 +67,7 @@
         strings. For example: <returnvalue>OK</returnvalue> encoded in
         UTF-8 is simply <returnvalue>OK</returnvalue>.  For more
         information on UTF-8:
-        http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8)
+        <ulink url="http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8"/>)
       </para>
     </section>
 

--- a/doc/protocol.xml
+++ b/doc/protocol.xml
@@ -66,7 +66,7 @@
         <function>strcpy</function> just fine with UTF-8 encoded
         strings. For example: <returnvalue>OK</returnvalue> encoded in
         UTF-8 is simply <returnvalue>OK</returnvalue>.  For more
-        information on UTF=8:
+        information on UTF-8:
         http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8)
       </para>
     </section>


### PR DESCRIPTION
(and replace `UTF=8` with `UTF-8`).