### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/src/db/Count.cxx
+++ b/src/db/Count.cxx
@@ -62,7 +62,7 @@ Print(Response &r, TagType group, const TagCountMap &m)
 	}
 }
 
-static bool
+static void
 stats_visitor_song(SearchStats &stats, const LightSong &song)
 {
 	stats.n_songs++;
@@ -70,8 +70,6 @@ stats_visitor_song(SearchStats &stats, const LightSong &song)
 	const auto duration = song.GetDuration();
 	if (!duration.IsNegative())
 		stats.total_duration += duration;
-
-	return true;
 }
 
 static bool
@@ -94,7 +92,7 @@ CollectGroupCounts(TagCountMap &map, TagType group, const Tag &tag)
 	return found;
 }
 
-static bool
+static void
 GroupCountVisitor(TagCountMap &map, TagType group, const LightSong &song)
 {
 	assert(song.tag != nullptr);
@@ -103,8 +101,6 @@ GroupCountVisitor(TagCountMap &map, TagType group, const LightSong &song)
 	if (!CollectGroupCounts(map, group, tag) && group == TAG_ALBUM_ARTIST)
 		/* fall back to "Artist" if no "AlbumArtist" was found */
 		CollectGroupCounts(map, TAG_ARTIST, tag);
-
-	return true;
 }
 
 void

--- a/src/db/DatabasePlaylist.cxx
+++ b/src/db/DatabasePlaylist.cxx
@@ -27,13 +27,12 @@
 
 #include <functional>
 
-static bool
+static void
 AddSong(const Storage &storage, const char *playlist_path_utf8,
 	const LightSong &song)
 {
 	spl_append_song(playlist_path_utf8,
 			DatabaseDetachSong(storage, song));
-	return true;
 }
 
 void

--- a/src/db/DatabasePrint.cxx
+++ b/src/db/DatabasePrint.cxx
@@ -49,16 +49,14 @@ PrintDirectoryURI(Response &r, bool base, const LightDirectory &directory)
 		 ApplyBaseFlag(directory.GetPath(), base));
 }
 
-static bool
+static void
 PrintDirectoryBrief(Response &r, bool base, const LightDirectory &directory)
 {
 	if (!directory.IsRoot())
 		PrintDirectoryURI(r, base, directory);
-
-	return true;
 }
 
-static bool
+static void
 PrintDirectoryFull(Response &r, bool base, const LightDirectory &directory)
 {
 	if (!directory.IsRoot()) {
@@ -67,8 +65,6 @@ PrintDirectoryFull(Response &r, bool base, const LightDirectory &directory)
 		if (directory.mtime > 0)
 			time_print(r, "Last-Modified", directory.mtime);
 	}
-
-	return true;
 }
 
 static void
@@ -96,7 +92,7 @@ print_playlist_in_directory(Response &r, bool base,
 			 directory->GetPath(), name_utf8);
 }
 
-static bool
+static void
 PrintSongBrief(Response &r, Partition &partition,
 	       bool base, const LightSong &song)
 {
@@ -106,11 +102,9 @@ PrintSongBrief(Response &r, Partition &partition,
 		/* this song file has an embedded CUE sheet */
 		print_playlist_in_directory(r, base,
 					    song.directory, song.uri);
-
-	return true;
 }
 
-static bool
+static void
 PrintSongFull(Response &r, Partition &partition,
 	      bool base, const LightSong &song)
 {
@@ -120,21 +114,18 @@ PrintSongFull(Response &r, Partition &partition,
 		/* this song file has an embedded CUE sheet */
 		print_playlist_in_directory(r, base,
 					    song.directory, song.uri);
-
-	return true;
 }
 
-static bool
+static void
 PrintPlaylistBrief(Response &r, bool base,
 		   const PlaylistInfo &playlist,
 		   const LightDirectory &directory)
 {
 	print_playlist_in_directory(r, base,
 				    &directory, playlist.name.c_str());
-	return true;
 }
 
-static bool
+static void
 PrintPlaylistFull(Response &r, bool base,
 		  const PlaylistInfo &playlist,
 		  const LightDirectory &directory)
@@ -144,8 +135,6 @@ PrintPlaylistFull(Response &r, bool base,
 
 	if (playlist.mtime > 0)
 		time_print(r, "Last-Modified", playlist.mtime);
-
-	return true;
 }
 
 void
@@ -191,15 +180,13 @@ db_selection_print(Response &r, Partition &partition,
 			   0, std::numeric_limits<int>::max());
 }
 
-static bool
+static void
 PrintSongURIVisitor(Response &r, Partition &partition, const LightSong &song)
 {
 	song_print_uri(r, partition, song);
-
-	return true;
 }
 
-static bool
+static void
 PrintUniqueTag(Response &r, TagType tag_type,
 	       const Tag &tag)
 {
@@ -211,8 +198,6 @@ PrintUniqueTag(Response &r, TagType tag_type,
 		if (item.type != tag_type)
 			r.Format("%s: %s\n",
 				 tag_item_names[item.type], item.value);
-
-	return true;
 }
 
 void

--- a/src/db/DatabaseQueue.cxx
+++ b/src/db/DatabaseQueue.cxx
@@ -27,14 +27,13 @@
 
 #include <functional>
 
-static bool
+static void
 AddToQueue(Partition &partition, const LightSong &song)
 {
 	const Storage &storage = *partition.instance.storage;
 	partition.playlist.AppendSong(partition.pc,
 				      DatabaseDetachSong(storage,
 							 song));
-	return true;
 }
 
 void

--- a/src/db/Helpers.cxx
+++ b/src/db/Helpers.cxx
@@ -67,15 +67,13 @@ StatsVisitTag(DatabaseStats &stats, StringSet &artists, StringSet &albums,
 	}
 }
 
-static bool
+static void
 StatsVisitSong(DatabaseStats &stats, StringSet &artists, StringSet &albums,
 	       const LightSong &song)
 {
 	++stats.song_count;
 
 	StatsVisitTag(stats, artists, albums, *song.tag);
-
-	return true;
 }
 
 DatabaseStats

--- a/src/util/VarSize.hxx
+++ b/src/util/VarSize.hxx
@@ -36,6 +36,7 @@
 #include <type_traits>
 #include <utility>
 #include <new>
+#include <cstdlib>
 
 /**
  * Allocate and construct a variable-size object.  That is useful for


### PR DESCRIPTION
Two patchsets are required to make mpd build successfully on FreeBSD. These are likely issues on other platforms as well.

-  src/util/VarSize.hxx requires cstdlib to be included to use free() . Probably on Linux this is pulled in via some other header and hence complies.
- During the overhaul of the DB methods, several method signatures no longer match the corresponding types in Interface.hxx. clang36 on FreeBSD-10 refuses to auto-convert the 'static bool' methods to the required 'void' and exits.