### PR TITLE
sidplay: require at least libsidplayfp 1.8.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -988,7 +988,7 @@ AM_CONDITIONAL(ENABLE_VORBIS_DECODER, test x$enable_vorbis = xyes || test x$enab
 dnl --------------------------------- sidplay ---------------------------------
 if test x$enable_sidplay != xno; then
 	dnl Check for libsidplayfp first
-	PKG_CHECK_MODULES([SIDPLAY], [libsidplayfp libsidutils],
+	PKG_CHECK_MODULES([SIDPLAY], [libsidplayfp >= 1.8.0 libsidutils],
 		[found_sidplayfp=yes],
 		[found_sidplayfp=no])
 	found_sidplay=$found_sidplayfp


### PR DESCRIPTION
With sidplayfp ->sidChips is used, which was introduced with version 1.8.

Signed-off-by: Olaf Hering <olaf@aepfle.de>