### PR TITLE
Add missing include for cstdlib, otherwise free() is undefined

### DIFF
--- a/src/decoder/plugins/WavpackDecoderPlugin.cxx
+++ b/src/decoder/plugins/WavpackDecoderPlugin.cxx
@@ -34,6 +34,8 @@
 #include <stdexcept>
 #include <memory>
 
+#include <cstdlib>
+
 #include <assert.h>
 
 #define ERRORLEN 80


### PR DESCRIPTION
On FreeBSD, and probably also on other BSDs, cstdlib is required to have free() defined.