### PR TITLE
Remove some redundant code

### DIFF
--- a/src/output/plugins/RoarOutputPlugin.cxx
+++ b/src/output/plugins/RoarOutputPlugin.cxx
@@ -287,8 +287,6 @@ roar_tag_convert(TagType type, bool *is_uuid)
 		case TAG_MUSICBRAINZ_ALBUMID:
 		case TAG_MUSICBRAINZ_ALBUMARTISTID:
 		case TAG_MUSICBRAINZ_TRACKID:
-			*is_uuid = true;
-			return "HASH";
 		case TAG_MUSICBRAINZ_RELEASETRACKID:
 			*is_uuid = true;
 			return "HASH";


### PR DESCRIPTION
I noticed this while looking for where to add code for another patch I'm about to submit. It looks like this code is not needed, since it's identical to the code in the next case. Falling through should achieve the same ends.